### PR TITLE
Prevent error in client browser console 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ We use `injectScript.js` to get the evolv remotecontext and send it to `evolvToo
 
 ---
 
-This extension is still in the very early stages and hasn't been widely used so please submit an issue when you got one.
-
----
-
 ## Future Ideas 
 * Log events as they are triggered.
 * Link each combinations to the experiment in the manager

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# EvoTools (beta)
-
+# EvoTools
 
 ## Getting Started
 ---
@@ -24,53 +23,23 @@
 
 ---
 
-#### **5)** We use `injectScript.js` to get the evolv remotecontext and send it to `evolvTool`. We actually have a bridge between webpage and `contentScript` to transfer data. We also can transfer data between `contentScript` and background as internal communication to make a complete data flow.
-
----
-
-#### **6)** Name the integration `EvoTools` and click the `Add New Connector` button at the bottom of the page.
-<img src="https://imgur.com/kBi2A9p.png"/>
-
----
-
-#### **7)** In the Connector Source dropdown, choose the `Gist` option.  In the `Gist` input, enter `153fb3d7cf8b170514343063cc2e43b5`.  Click the `Create` button in the top right corner.  If you don't see your integration appear in the list of integrations, refresh the page.
-<img src="https://imgur.com/p8lrM1H.png"/>
-
----
-
-#### **8)** Navigate to the `Environments` tab and click on the environment that you'd like to add the integration to.  When the side-drawer opens, click the `Integrations` tab followed by the `Add Integration` dropdown.  Choose `EvoTools` and then click `Save` in the top right corner.
-<img src="https://imgur.com/9n2qKcL.png"/>
-
----
-
-#### **9)** You're all set up!  Navigate to a page that you know has an active experiment, click the extension icon, and validate that you are seeing data.
+#### **5)** You're all set up!  Navigate to a page that you know has an active experiment, click the extension icon, and validate that you are seeing data.
 <img src="https://imgur.com/AHn9ubo.png"/>
 
-
----
 ---
 
-
-This extension is still in the very early stages and hasn't been widely used so please report any issues or feature requests to brian.norman@evolv.ai.
+### Note:
+We use `injectScript.js` to get the evolv remotecontext and send it to `evolvTool`. We actually have a bridge between webpage and `contentScript` to transfer data. We also can transfer data between `contentScript` and background as internal communication to make a complete data flow.
 
 ---
 
-## Possible Names for Extension:
-* Evolv Debugger
-* Evolv Assistant
-* EvoEye
-* Evolv Aeye
-* EvoSpy
-* Evolv Inspector
-* Inspector Evo
+This extension is still in the very early stages and hasn't been widely used so please submit an issue when you got one.
 
 ---
 
 ## Future Ideas 
-* Get extension into the Chrome store so that the install process is quick and easy.
-* Convince Rob to add remoteContext to `sessionStorage` so that we can eliminate the need for the integration.
 * Log events as they are triggered.
-* Link each combinations to the experiment in the manager - need to get orgID and projectId somehow in order to create a link
+* Link each combinations to the experiment in the manager
 * List audiences user has qualified for
 * Select desired combination - would likely need to talk to the manager
 * Replicate `Resource Override`'s script injection/redirect functionality to eliminate the need for that extension.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,11 +1,14 @@
-
-let connectionPort;
-
 const initData = {};
+let isPopupOpen = false
 
 const injectScript = () => {
+    if (document.getElementById('evolvTools:injectedScript')) {
+        return;
+    }
+
     var script = document.createElement('script');
     script.src = chrome.runtime.getURL('injectScript.js');
+    script.id = 'evolvTools:injectedScript';
     document.body.appendChild(script);
 }
 
@@ -24,7 +27,9 @@ waitForElement('script[src*="evolv.ai/asset-manager"]').then(script => {
     const envID = script.dataset.evolvEnvironment;
 
     initData.envID = envID;
-    chrome.runtime.sendMessage({ message: 'evolv:envId', data: envID });
+    if (isPopupOpen){
+        chrome.runtime.sendMessage({ message: 'evolv:envId', data: envID });
+    }
 });
 
 const bootstrap = () => {
@@ -42,7 +47,9 @@ window.addEventListener('message', (e) => {
     switch (e.data.type) {
         case 'evolv:context':
             initData.remoteContext = e.data.data;
-            chrome.runtime.sendMessage({ message: 'evoTools:remoteContext', data: e.data.data });
+            if (isPopupOpen){
+                chrome.runtime.sendMessage({ message: 'evoTools:remoteContext', data: e.data.data });
+            }
     }
 });
 
@@ -68,7 +75,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             }, '*');
             bootstrap();
             break;
+        case 'evolv_popup_closed':
+            isPopupOpen= false;
+            break;
+        case 'ping_content_script':
+            isPopupOpen = true;
+            break;
     }
 });
-
-bootstrap();


### PR DESCRIPTION
prevent `Uncaught (in promise) Error: Could not establish connection. Receiving end does not exist.` from appearing in browser console when popup is closed. The error was not affecting any functionalities but we should not let browser show throw it.

before:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/18535332/214962929-59e7b01e-04dc-4383-98ef-24902a991dcc.png">

after:
<img width="780" alt="image" src="https://user-images.githubusercontent.com/18535332/214963460-bde4afb9-e08d-4d8f-95ff-00a9a2759e29.png">

**Note:**
This error happens in popup console and it's fine. We can't prevent it as it's coming from browser messaging system
