### PR TITLE
fix(AP-3960): Fix snippet detection for prod accounts

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -29,6 +29,10 @@ window.addEventListener("load", () => {
 });
 
 const getStage = (evolvEndpoint: string): Stage => {
+    if (!evolvEndpoint) {
+        return Stage.Production;
+    }
+
     if (evolvEndpoint.includes('-stg')) {
         return Stage.Staging;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface InitData {
 	uid: string;
 	blockExecution?: BlockExecution;
 	previewCid: string | null;
-	stage: Stage | null;
+	stage: Stage | undefined;
 	snippetIsDisabled: boolean;
 }
 


### PR DESCRIPTION
[AP-3960](https://evolv-ai.atlassian.net/browse/AP-3960)

- The code was failing to detect the snippet on prod because the dataSet value was undefined.

[AP-3960]: https://evolv-ai.atlassian.net/browse/AP-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ