### PR TITLE
feat: read internal confirmations as well

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -37,7 +37,7 @@ const getStage = (evolvEndpoint: string): Stage => {
         return Stage.Staging;
     }
 
-    if (evolvEndpoint.includes('-dev')) {
+    if (evolvEndpoint.includes('-newdev')) {
         return Stage.Development;
     }
 
@@ -57,7 +57,7 @@ const waitForEvolv = async () => {
       : strings.snippet.notDetected;
 
     try {
-        const script: HTMLScriptElement | unknown = await waitForElement('script[src*="evolv.ai/asset-manager"]');
+        const script: HTMLScriptElement | unknown = await waitForElement('script[src*="evolv.ai/asset-manager"], script[src*="localhost"][src*="webloader"]');
 
         if (script instanceof HTMLScriptElement) {
             initData.envID = script.dataset.evolvEnvironment;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -88,7 +88,9 @@ const handleSettingsButtonClicks = () => {
 const setAllocationsAndConfirmations = () => {
   if (remoteContext && remoteContext.experiments && !snippetIsDisabled) {
     const allocations = remoteContext.experiments.allocations;
-    const confirmations = remoteContext.experiments.confirmations;
+    const confirmationsStandard = remoteContext.experiments.confirmations ?? [];
+    const confirmationsInternal = remoteContext.experiments.confirmationsinternal ?? [];
+    const confirmations = [...confirmationsStandard, ...confirmationsInternal];
     const experimentNames = remoteContext.experimentNames;
 
     let confirmationCIDs: string[] = [];

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -89,7 +89,7 @@ const setAllocationsAndConfirmations = () => {
   if (remoteContext && remoteContext.experiments && !snippetIsDisabled) {
     const allocations = remoteContext.experiments.allocations;
     const confirmationsStandard = remoteContext.experiments.confirmations ?? [];
-    const confirmationsInternal = remoteContext.experiments.confirmationsinternal ?? [];
+    const confirmationsInternal = remoteContext.experiments.confirmationsInternal ?? [];
     const confirmations = [...confirmationsStandard, ...confirmationsInternal];
     const experimentNames = remoteContext.experimentNames;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type Experiments = {
 	allocations: Allocation[];
 	exclusions: string[];
 	confirmations: Confirmation[];
+	confirmationsinternal: Confirmation[];
 }
 
 export interface Allocation {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type Experiments = {
 	allocations: Allocation[];
 	exclusions: string[];
 	confirmations: Confirmation[];
-	confirmationsinternal: Confirmation[];
+	confirmationsInternal: Confirmation[];
 }
 
 export interface Allocation {


### PR DESCRIPTION
[AP-5710]

shows internal confirmations as well to preserve the current experience

Right now it just shows them all as the same thing. You think I ought to try moving them to separate sections? I get the feeling only one section will be populated at a time though

[AP-5710]: https://evolv-ai.atlassian.net/browse/AP-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ