### PR TITLE
feat: internal user indicator

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -72,6 +72,7 @@
           </li>
           <li>
             <span id="evolv_uid">-</span>
+            <span id="evolv_internal_user_indicator"></span>
           </li>
         </ul>
       </div>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -47,6 +47,12 @@ const setUidValue = (uid: string) => {
   });
 };
 
+const setInternalUserIndicator = () => {
+  waitForElement("#evolv_internal_user_indicator").then(function (indicator: HTMLElement) {
+    indicator.textContent = '-[internal]';
+  });
+};
+
 const setEnvironmentValue = (value: string) => {
   waitForElement("#envID").then(function (envInput: HTMLElement) {
       envInput.textContent = value || '(not set)';
@@ -417,6 +423,10 @@ const setConfig = (stage: Stage) => {
     try {
       chrome.runtime.sendMessage({type: 'evolv:environmentConfig', envId: environmentId, stage}, response => {
         if (response.data) {
+          if (response.data._internal_user) {
+            setInternalUserIndicator();
+          }
+
           const experiments = response.data._experiments;
 
           if (experiments && experiments.length) {


### PR DESCRIPTION
[AP-5710]

show a little text indicator for internal users

<img width="572" alt="Screenshot 2025-05-07 at 10 48 10 PM" src="https://github.com/user-attachments/assets/9504a57a-78a7-47e5-a736-3d7bd24bac02" />


[AP-5710]: https://evolv-ai.atlassian.net/browse/AP-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ