### PR TITLE
fix: fetch the right config for internal uers

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -4,27 +4,45 @@ interface Request {
   type: string;
   stage: Stage;
   envId: string;
+  uid?: string;
 }
 
-chrome.runtime.onMessage.addListener(({ type, stage, envId }: Request, sender, sendMessage): boolean => {
+interface Response {
+  data?: unknown;
+  error?: string;
+}
+
+function fetchFromParticipants(url: string, sendMessage: (response: Response) => void) {
+  return fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+    .then(response => response.json())
+    .then(data => {
+      sendMessage({ data });
+    })
+    .catch(error => {
+      sendMessage({ error: error.message });
+    });
+}
+
+chrome.runtime.onMessage.addListener(({ type, stage, envId, uid }: Request, sender, sendMessage): boolean => {
   if (type === 'evolv:environmentConfig') {
-    const url: string = stage === Stage.Development
+    const envConfigUrl: string = stage === Stage.Development
       ? `https://participants-newdev.evolvdev.com/v1/${envId}`
       : `https://participants${stage}.evolv.ai/v1/${envId}`;
 
-    fetch(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
-      .then(response => response.json())
-      .then(data => {
-        sendMessage({ data });
-      })
-      .catch(error => {
-        sendMessage({ error: error.message });
-      });
+    fetchFromParticipants(envConfigUrl, sendMessage);
+  }
+
+  if (type === 'evolv:userConfig') {
+    const userConfigUrl: string = stage === Stage.Development
+      ? `https://participants-newdev.evolvdev.com/v1/${envId}/${uid}/configuration.json`
+      : `https://participants${stage}.evolv.ai/v1/${envId}/${uid}/configuration.json`;
+
+    fetchFromParticipants(userConfigUrl, sendMessage);
   }
 
   return true;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -418,10 +418,26 @@ const setEvents = () => {
   }
 };
 
-const setConfig = (stage: Stage) => {
+const setConfig = (stage: Stage, uid: string) => {
   if (environmentId) {
+    if (uid) {
+      try {
+        chrome.runtime.sendMessage({ type: 'evolv:userConfig', envId: environmentId, stage, uid }, response => {
+          if (response.data) {
+            if (response.data._internal_user) {
+              setInternalUserIndicator();
+            }
+          } else {
+            console.error("Fetch user config error: ", response.error);
+          }
+        });
+      } catch (error) {
+        console.error("Fetch user config failed: ", error);
+      }
+    }
+
     try {
-      chrome.runtime.sendMessage({type: 'evolv:environmentConfig', envId: environmentId, stage}, response => {
+      chrome.runtime.sendMessage({ type: 'evolv:environmentConfig', envId: environmentId, stage }, response => {
         if (response.data) {
           if (response.data._internal_user) {
             setInternalUserIndicator();
@@ -478,8 +494,9 @@ chrome.runtime.onMessage.addListener((msg) => {
       handleClearSelectionClicks();
       setEnvironmentValue(environmentId);
       setBlockExecutionStatus(msg.data.blockExecution);
-      setUidValue(msg.data.uid);
-      setConfig(msg.data.stage);
+      const uid = msg.data.uid
+      setUidValue(uid);
+      setConfig(msg.data.stage, uid);
       setEvents();
       break;
   }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -439,10 +439,6 @@ const setConfig = (stage: Stage, uid: string) => {
     try {
       chrome.runtime.sendMessage({ type: 'evolv:environmentConfig', envId: environmentId, stage }, response => {
         if (response.data) {
-          if (response.data._internal_user) {
-            setInternalUserIndicator();
-          }
-
           const experiments = response.data._experiments;
 
           if (experiments && experiments.length) {


### PR DESCRIPTION
[AP-5710]

the value isn't in the environmental config, so we'll also fetch the user config to get it. Unfortunately, we can't just rely on the user config since the experiments values seem to have a different shape/data

[AP-5710]: https://evolv-ai.atlassian.net/browse/AP-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ